### PR TITLE
141 - Actualización lista de rangos

### DIFF
--- a/components/MemberCard/MemberCard.tsx
+++ b/components/MemberCard/MemberCard.tsx
@@ -4,6 +4,7 @@ import { SanityClientOrProjectDetails, useNextSanityImage } from 'next-sanity-im
 import Image from 'next/image';
 import { FC } from 'react';
 import { SanityImageSource } from '@sanity/image-url/lib/types/types';
+import { NO_PROFILE_IMAGE } from 'utils/constants';
 
 type MemberCardProps = {
   name: string;
@@ -12,8 +13,6 @@ type MemberCardProps = {
 };
 
 const MemberCard: FC<MemberCardProps> = ({ name, description, image }): JSX.Element => {
-  const NO_PROFILE_IMAGE = '/no-profile-image.png';
-
   const imageProps = useNextSanityImage(sanityConfig as SanityClientOrProjectDetails, image);
 
   const src = imageProps?.src || NO_PROFILE_IMAGE;
@@ -22,10 +21,11 @@ const MemberCard: FC<MemberCardProps> = ({ name, description, image }): JSX.Elem
     <figure id="hero" className={styles.root}>
       <div className={styles.imageContainer}>
         <Image
-          src={src}
-          fill
           alt={name}
           className={styles.image}
+          height={100}
+          width={100}
+          src={src}
           style={{
             objectFit: 'cover',
           }}

--- a/pages/cuerpo-activo.tsx
+++ b/pages/cuerpo-activo.tsx
@@ -14,9 +14,7 @@ import HeroInstitucional from 'components/HeroInstitucional/HeroInstitucional';
 
 const CuerpoActivo: FC<ActiveForceType> = ({ list }): JSX.Element => {
   const { orderedList, getTranslation } = groupAndOrder('rank', list);
-  const addSubtitle = (value: string | 'comandante-general' | 'comandante') =>
-    (value === 'comandante-general' && ' - Jefe del Cuerpo') ||
-    (value === 'comandante' && ' - 2do. Jefe del Cuerpo');
+
   return (
     <Layout title="Cuerpo Activo">
       <div className="min-h-screen">
@@ -27,10 +25,7 @@ const CuerpoActivo: FC<ActiveForceType> = ({ list }): JSX.Element => {
               <div key={key}>
                 <div className="flex flex-col items-center max-w-6xl pt-6 pb-6 mx-auto border-b-2 border-yellow-400 md:flex-row">
                   <Fade cascade>
-                    <h2 className="text-4xl font-light text-gray-900 ">
-                      {getTranslation(key)}
-                      <span className="text-3xl text-gray-500">{addSubtitle(key) || ''}</span>
-                    </h2>
+                    <h2 className="text-4xl font-light text-gray-900 ">{getTranslation(key)}</h2>
                   </Fade>
                 </div>
                 <div className="grid max-w-6xl gap-3 p-8 pb-12 mx-auto mt-6 md:grid-cols-3 sm:grid-cols-2">

--- a/studio/schemas/activeForce.js
+++ b/studio/schemas/activeForce.js
@@ -1,3 +1,5 @@
+import { RANKS } from 'utils/constants';
+
 export default {
   name: 'activeForce',
   type: 'document',
@@ -15,25 +17,7 @@ export default {
       type: 'string',
       validation: (Rule) => Rule.required(),
       options: {
-        list: [
-          { title: 'Comandante General', value: 'comandante-general' },
-          { title: 'Comandante Mayor', value: 'comandante-mayor' },
-          { title: 'Comandante', value: 'comandante' },
-          { title: 'Subcomandante', value: 'subcomandante' },
-          { title: 'Oficial Principal', value: 'oficial-principal' },
-          { title: 'Oficial Inspector', value: 'oficial-inspector' },
-          { title: 'Oficial Ayudante', value: 'oficial-ayudante' },
-          { title: 'Suboficial Mayor', value: 'suboficial-mayor' },
-          { title: 'Suboficial Principal', value: 'suboficial-principal' },
-          { title: 'Suboficial Primero', value: 'suboficial-primero' },
-          { title: 'Sargento Primero', value: 'sargento-primero' },
-          { title: 'Sargento', value: 'sargento' },
-          { title: 'Cabo Primero', value: 'cabo-primero' },
-          { title: 'Cabo', value: 'cabo' },
-          { title: 'Bombero', value: 'bombero' },
-          { title: 'Aspirante', value: 'aspirante' },
-          // {title: 'Cadete', value: 'cadete'},
-        ],
+        list: RANKS,
       },
     },
     {

--- a/studio/schemas/leadership.js
+++ b/studio/schemas/leadership.js
@@ -1,3 +1,5 @@
+import { POSITIONS } from 'utils/constants';
+
 export default {
   name: 'leadership',
   type: 'document',
@@ -18,18 +20,7 @@ export default {
       type: 'string',
       validation: (Rule) => Rule.required(),
       options: {
-        list: [
-          { title: 'Presidente', value: 'presidente' },
-          { title: 'Vice Presidente', value: 'vice-presidente' },
-          { title: 'Secretario', value: 'secretario' },
-          { title: 'Pro secretario', value: 'pro-secretario' },
-          { title: 'Tesorero', value: 'tesorero' },
-          { title: 'Pro tesorero', value: 'pro-tesorero' },
-          { title: 'Vocal Titular', value: 'vocal-titular' },
-          { title: 'Vocal Suplente', value: 'vocal-suplente' },
-          { title: 'Rev. de Ctas. Titular', value: 'cuentas-titular' },
-          { title: 'Rev. de Ctas. Suplente', value: 'cuentas-suplente' },
-        ],
+        list: POSITIONS,
       },
     },
     {

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -107,3 +107,42 @@ export const ACADEMY_MEMBERS = [
     name: 'Franco Pifaretti',
   },
 ];
+
+// This list feeds both Sanity and Website
+export const RANKS = [
+  { title: 'Jefe del Cuerpo', value: 'jefe-del-cuerpo' },
+  { title: '2do. Jefe del Cuerpo', value: 'segundo-jefe-del-cuerpo' },
+  { title: 'Comandante General', value: 'comandante-general' },
+  { title: 'Comandante Mayor', value: 'comandante-mayor' },
+  { title: 'Comandante', value: 'comandante' },
+  { title: 'Subcomandante', value: 'subcomandante' },
+  { title: 'Oficial Principal', value: 'oficial-principal' },
+  { title: 'Oficial Inspector', value: 'oficial-inspector' },
+  { title: 'Oficial Ayudante', value: 'oficial-ayudante' },
+  { title: 'Suboficial Mayor', value: 'suboficial-mayor' },
+  { title: 'Suboficial Principal', value: 'suboficial-principal' },
+  { title: 'Suboficial Primero', value: 'suboficial-primero' },
+  { title: 'Sargento Primero', value: 'sargento-primero' },
+  { title: 'Sargento', value: 'sargento' },
+  { title: 'Cabo Primero', value: 'cabo-primero' },
+  { title: 'Cabo', value: 'cabo' },
+  { title: 'Bombero', value: 'bombero' },
+  { title: 'Aspirante', value: 'aspirante' },
+];
+
+// This list feeds both Sanity and Website
+export const POSITIONS = [
+  { title: 'Presidente', value: 'presidente' },
+  { title: 'Vice Presidente', value: 'vice-presidente' },
+  { title: 'Secretario', value: 'secretario' },
+  { title: 'Pro secretario', value: 'pro-secretario' },
+  { title: 'Tesorero', value: 'tesorero' },
+  { title: 'Pro tesorero', value: 'pro-tesorero' },
+  { title: 'Vocal Titular', value: 'vocal-titular' },
+  { title: 'Vocal Suplente', value: 'vocal-suplente' },
+  { title: 'Rev. de Ctas. Titular', value: 'cuentas-titular' },
+  { title: 'Rev. de Ctas. Suplente', value: 'cuentas-suplente' },
+];
+
+// Used when there is no profile image of a member
+export const NO_PROFILE_IMAGE = '/no-profile-image.png';

--- a/utils/list.ts
+++ b/utils/list.ts
@@ -1,55 +1,26 @@
 import { ActiveForcePerson, ComisionPerson } from 'types/News';
 import { find, orderBy, groupBy, Dictionary } from 'lodash';
-
-const positions = [
-  { title: 'Presidente', value: 'presidente' },
-  { title: 'Vice Presidente', value: 'vice-presidente' },
-  { title: 'Secretario', value: 'secretario' },
-  { title: 'Pro secretario', value: 'pro-secretario' },
-  { title: 'Tesorero', value: 'tesorero' },
-  { title: 'Pro tesorero', value: 'pro-tesorero' },
-  { title: 'Vocal Titular', value: 'vocal-titular' },
-  { title: 'Vocal Suplente', value: 'vocal-suplente' },
-  { title: 'Rev. de Ctas. Titular', value: 'cuentas-titular' },
-  { title: 'Rev. de Ctas. Suplente', value: 'cuentas-suplente' },
-];
-
-const ranks = [
-  { title: 'Comandante General', value: 'comandante-general' },
-  { title: 'Comandante Mayor', value: 'comandante-mayor' },
-  { title: 'Comandante', value: 'comandante' },
-  { title: 'Subcomandante', value: 'subcomandante' },
-  { title: 'Oficial Principal', value: 'oficial-principal' },
-  { title: 'Oficial Inspector', value: 'oficial-inspector' },
-  { title: 'Oficial Ayudante', value: 'oficial-ayudante' },
-  { title: 'Suboficial Mayor', value: 'suboficial-mayor' },
-  { title: 'Suboficial Principal', value: 'suboficial-principal' },
-  { title: 'Suboficial Primero', value: 'suboficial-primero' },
-  { title: 'Sargento Primero', value: 'sargento-primero' },
-  { title: 'Sargento', value: 'sargento' },
-  { title: 'Cabo Primero', value: 'cabo-primero' },
-  { title: 'Cabo', value: 'cabo' },
-  { title: 'Bombero', value: 'bombero' },
-  { title: 'Aspirante', value: 'aspirante' },
-];
+import { RANKS, POSITIONS } from './constants';
 
 const orderRanks = {
-  'comandante-general': 1,
-  'comandante-mayor': 2,
-  comandante: 3,
-  subcomandante: 4,
-  'oficial-principal': 5,
-  'oficial-inspector': 6,
-  'oficial-ayudante': 7,
-  'suboficial-mayor': 8,
-  'suboficial-principal': 9,
-  'suboficial-primero': 10,
-  'sargento-primero': 11,
-  sargento: 12,
-  'cabo-primero': 13,
-  cabo: 14,
-  bombero: 15,
-  aspirante: 16,
+  'jefe-del-cuerpo': 1,
+  'segundo-jefe-del-cuerpo': 2,
+  'comandante-general': 3,
+  'comandante-mayor': 4,
+  comandante: 5,
+  subcomandante: 6,
+  'oficial-principal': 7,
+  'oficial-inspector': 8,
+  'oficial-ayudante': 9,
+  'suboficial-mayor': 10,
+  'suboficial-principal': 11,
+  'suboficial-primero': 12,
+  'sargento-primero': 13,
+  sargento: 14,
+  'cabo-primero': 15,
+  cabo: 16,
+  bombero: 17,
+  aspirante: 18,
 };
 
 const orderPositions = {
@@ -71,7 +42,7 @@ type MembersList = {
 };
 
 const groupAndOrderPosition = (list: ComisionPerson[]) => {
-  const getTranslatedPositions = (value) => find(positions, { value })?.title;
+  const getTranslatedPositions = (value) => find(POSITIONS, { value })?.title;
   const orderByPosition = orderBy(list, (l) => orderPositions[l.position]);
   return {
     orderedList: groupBy(orderByPosition, 'position'),
@@ -80,7 +51,7 @@ const groupAndOrderPosition = (list: ComisionPerson[]) => {
 };
 
 const groupAndOrderRanks = (list: ActiveForcePerson[]) => {
-  const getTranslatedRanks = (value) => find(ranks, { value })?.title;
+  const getTranslatedRanks = (value) => find(RANKS, { value })?.title;
   const orderByRank = orderBy(list, (l) => orderRanks[l.rank]);
 
   return { orderedList: groupBy(orderByRank, 'rank'), getTranslation: getTranslatedRanks };


### PR DESCRIPTION
* Agregamos nuevos rangos
* Quitamos hardcodeo de la página `cuerpo-active.tsx`
* Exportamos listas de rangos y jerarquías en listas constantes a usarse tanto en Sanity como en el sitio (para Cuerpo Activo y Comisión Directiva respectivamente)